### PR TITLE
User page map correctly hides visits on private vacations

### DIFF
--- a/app/controllers/api/v1/user_visits_controller.rb
+++ b/app/controllers/api/v1/user_visits_controller.rb
@@ -3,8 +3,11 @@ class Api::V1::UserVisitsController < ApplicationController
   def show
     user = User.find(params[:id])
     # only lists parks that were visited in a publicly listed vacation
-    visited_parks = user.parks.uniq
-    # visited_parks = user.visits.map { |visit| visit.park if (visit.vacation.display_public == true) }.uniq
+    if current_user == user
+      visited_parks = user.parks.uniq
+    else
+      visited_parks = user.visits.map { |visit| visit.park if (visit.vacation.display_public == true) }.uniq
+    end
 
     list = []
     Park.all.each_with_index do |park, index|


### PR DESCRIPTION
Previously, the map on a users page would display and link to visits to a park that were part of a private vacation. This has been amended at the serializer level to only show both private and public vacations to the user viewing _their_ account.